### PR TITLE
ar71xx: Add support for Ubiquiti LiteBeam ac AP

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -79,6 +79,7 @@ ar71xx_setup_interfaces()
 	fritz300e|\
 	gl-usb150|\
 	hiveap-121|\
+	lbe-5ac-16-120|\
 	loco-m-xw|\
 	mr12|\
 	mr16|\

--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
@@ -111,6 +111,7 @@ case "$FIRMWARE" in
 		ath10kcal_extract "art" 20480 2116
 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
 		;;
+	lbe-5ac-16-120|\
 	nanostationacl|\
 	unifiac-lite|\
 	unifiac-pro)

--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
+++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
@@ -1250,6 +1250,9 @@ ar71xx_board_detect() {
 	*"Tube2H")
 		name="tube2h"
 		;;
+	*"Ubiquiti LiteBeam ac AP")
+		name="lbe-5ac-16-120"
+		;;
 	*"Ubiquiti Nanostation AC loco")
 		name="nanostationacl"
 		;;

--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
@@ -250,6 +250,7 @@ platform_check_image() {
 	hornet-ub-x2|\
 	jwap230|\
 	lima|\
+	lbe-5ac-16-120|\
 	loco-m-xw|\
 	mzk-w04nu|\
 	mzk-w300nh|\

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-ubnt-wa.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-ubnt-wa.c
@@ -92,5 +92,8 @@ static void __init ubnt_wa_setup(void)
 MIPS_MACHINE(ATH79_MACH_UBNT_WA, "UBNT-WA",
 	     "Ubiquiti Networks WA board", ubnt_wa_setup);
 
+MIPS_MACHINE(ATH79_MACH_UBNT_LITEBEAMACAP, "UBNT-LITEBEAMACAP",
+	     "Ubiquiti LiteBeam ac AP", ubnt_wa_setup);
+
 MIPS_MACHINE(ATH79_MACH_UBNT_NANOSTATIONACL, "UBNT-NANOSTATION-ACL",
 	     "Ubiquiti Nanostation AC loco", ubnt_wa_setup);

--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
@@ -289,6 +289,7 @@ enum ath79_mach_type {
 	ATH79_MACH_UBNT_AIRGWP,			/* Ubiquiti AirGateway Pro */
 	ATH79_MACH_UBNT_AIRROUTER,		/* Ubiquiti AirRouter */
 	ATH79_MACH_UBNT_BULLET_M,		/* Ubiquiti Bullet M */
+	ATH79_MACH_UBNT_LITEBEAMACAP,		/* Ubiquiti LiteBeam ac AP */
 	ATH79_MACH_UBNT_LOCO_M_XW,		/* Ubiquiti Loco M XW */
 	ATH79_MACH_UBNT_LSSR71,			/* Ubiquiti LS-SR71 */
 	ATH79_MACH_UBNT_LSX,			/* Ubiquiti LSX */

--- a/target/linux/ar71xx/image/generic-ubnt.mk
+++ b/target/linux/ar71xx/image/generic-ubnt.mk
@@ -163,6 +163,20 @@ define Device/ubnt-unifiac-pro
 endef
 TARGET_DEVICES += ubnt-unifiac-pro
 
+define Device/ubnt-lbe-5ac-16-120
+  $(Device/ubnt-wa)
+  DEVICE_TITLE := Ubiquiti LiteBeam ac AP
+  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca988x
+  DEVICE_PROFILE += UBNTLITEBEAMACAP
+  BOARDNAME := UBNT-LITEBEAMACAP
+  IMAGE_SIZE := 15744k
+  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,15744k(firmware),256k(cfg)ro,64k(EEPROM)ro
+  IMAGES := factory.bin sysupgrade.bin
+  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+  IMAGE/factory.bin := $$(IMAGE/sysupgrade.bin) | mkubntimage-split-wa
+endef
+TARGET_DEVICES += ubnt-lbe-5ac-16-120
+
 define Device/ubnt-nanostationacl
   $(Device/ubnt-wa)
   DEVICE_TITLE := Ubiquiti Nanostation AC loco


### PR DESCRIPTION
This commit adds support for the LiteBeam ac AP (model LBE-5AC-16-120),
a 802.11ac router with a 16 dBi and 120º sector antenna and one Gigabit
Ethernet port.

Working:
 - Board identification, CPU, etc.
 - Ethernet port
 - Wireless
 - Button

The board is very similar to the NanoStation AC loco, on which this
commit is based (they share the WA board design). The same flashing
processes described at openwrt#689 apply here.